### PR TITLE
Added script for creating a DEB file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# DEB
+deb_tmp/

--- a/installer.sh
+++ b/installer.sh
@@ -88,6 +88,7 @@ bin_install(){
     else
         ln -sfT /usr/share/WiFi-Pumpkin/wifi-pumpkin /usr/bin/wifi-pumpkin
     fi
+    cp wifi-pumpkin.desktop /usr/share/applications/wifi-pumpkin.desktop
     chmod +x /usr/share/WiFi-Pumpkin/wifi-pumpkin
 }
 
@@ -102,6 +103,7 @@ uninstall(){
             else
                 rm /usr/bin/wifi-pumpkin
             fi
+            rm /usr/share/applications/wifi-pumpkin.desktop
 	    echo "[$red_color-$txtrst] Deleted Binary:$bldwht/usr/bin/wifi-pumpkin $txtrst"
             echo "[$red_color-$txtrst] Delete Path:$bldwht $DIRECTORY $txtrst"
 	    rm -r $path_uninstall

--- a/make_deb.sh
+++ b/make_deb.sh
@@ -4,10 +4,13 @@ VERSION=$(date +%Y%m%d)
 DEB_ROOT="deb_tmp/wifi-pumpkin_$VERSION"
 INSTALL_PATH=/usr/share/WiFi-Pumpkin
 mkdir -p $DEB_ROOT$INSTALL_PATH
+mkdir -p $DEB_ROOT/usr/share/applications
 
 tar cf - --exclude=deb_tmp --exclude=./.git . | (cd $DEB_ROOT$INSTALL_PATH && tar xvf - > /dev/null)
-mkdir -p $DEB_ROOT/DEBIAN
 
+cp wifi-pumpkin.desktop $DEB_ROOT/usr/share/applications/wifi-pumpkin.desktop
+
+mkdir -p $DEB_ROOT/DEBIAN
 SIZE=$(du -sb $DEB_ROOT$INSTALL_PATH | cut -f1 | awk '{print $1/1024}')
 
 ###### Start of the DEBIAN/control file ######

--- a/make_deb.sh
+++ b/make_deb.sh
@@ -8,11 +8,14 @@ mkdir -p $DEB_ROOT$INSTALL_PATH
 tar cf - --exclude=deb_tmp --exclude=./.git . | (cd $DEB_ROOT$INSTALL_PATH && tar xvf - > /dev/null)
 mkdir -p $DEB_ROOT/DEBIAN
 
+SIZE=$(du -sb $DEB_ROOT$INSTALL_PATH | cut -f1 | awk '{print $1/1024}')
+
 ###### Start of the DEBIAN/control file ######
 cat > $DEB_ROOT/DEBIAN/control << EOF
 Package: wifi-pumpkin
 Version: $VERSION
 Priority: optional
+Installed-Size: $SIZE
 Architecture: i386
 Maintainer: Marcos Nesster <mh4root@gmail.com>
 #Depends: python-pip, libffi-dev, libssl-dev, libxml2-dev, libxslt1-dev, zlib1g-dev, libarchive-dev, build-essential, libnetfilter-queue-dev, python-qt4, python-scapy, hostapd, rfkill, python-dev, git, libpcap-dev

--- a/make_deb.sh
+++ b/make_deb.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+VERSION=$(date +%Y%m%d)
+DEB_ROOT="deb_tmp/wifi-pumpkin_$VERSION"
+INSTALL_PATH=/usr/share/WiFi-Pumpkin
+mkdir -p $DEB_ROOT$INSTALL_PATH
+
+tar cf - --exclude=deb_tmp --exclude=./.git . | (cd $DEB_ROOT$INSTALL_PATH && tar xvf - > /dev/null)
+mkdir -p $DEB_ROOT/DEBIAN
+
+###### Start of the DEBIAN/control file ######
+cat > $DEB_ROOT/DEBIAN/control << EOF
+Package: wifi-pumpkin
+Version: $VERSION
+Priority: optional
+Architecture: i386
+Maintainer: Marcos Nesster <mh4root@gmail.com>
+#Depends: python-pip, libffi-dev, libssl-dev, libxml2-dev, libxslt1-dev, zlib1g-dev, libarchive-dev, build-essential, libnetfilter-queue-dev, python-qt4, python-scapy, hostapd, rfkill, python-dev, git, libpcap-dev
+Description: WiFi-Pumpkin
+ A tool for creating a WiFi-Hotspot and executing MitM-Attacks
+EOF
+###### END of the DEBIAN/control file ######
+
+###### Start of the DEBIAN/postinst file ######
+cat > $DEB_ROOT/DEBIAN/postinst << EOF
+#!/bin/bash
+pip install -r $INSTALL_PATH/requirements.txt
+if which update-alternatives >/dev/null; then
+        update-alternatives --install /usr/bin/wifi-pumpkin wifi-pumpkin $INSTALL_PATH/wifi-pumpkin 1 > /dev/null
+    else
+        ln -sfT $INSTALL_PATH/wifi-pumpkin /usr/bin/wifi-pumpkin
+    fi
+    chmod +x $INSTALL_PATH/wifi-pumpkin
+EOF
+###### END of the DEBIAN/postinst file ######
+
+chmod 0755 $DEB_ROOT/DEBIAN/postinst
+
+cd deb_tmp
+dpkg-deb --build wifi-pumpkin_$VERSION

--- a/make_deb.sh
+++ b/make_deb.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
-
-for ARCHITECTURE in i386 amd64; do
-
+ARCHITECTURE="all"
 VERSION=$(date +%Y%m%d)
 DEB_ROOT="deb_tmp/wifi-pumpkin_${VERSION}_$ARCHITECTURE"
 INSTALL_PATH=/usr/share/WiFi-Pumpkin
@@ -51,4 +49,3 @@ cd deb_tmp
 dpkg-deb --build wifi-pumpkin_${VERSION}_${ARCHITECTURE}
 cd ..
 
-done

--- a/make_deb.sh
+++ b/make_deb.sh
@@ -1,17 +1,22 @@
 #!/bin/bash
 
+for ARCHITECTURE in i386 amd64; do
+
 VERSION=$(date +%Y%m%d)
-DEB_ROOT="deb_tmp/wifi-pumpkin_$VERSION"
+DEB_ROOT="deb_tmp/wifi-pumpkin_${VERSION}_$ARCHITECTURE"
 INSTALL_PATH=/usr/share/WiFi-Pumpkin
-mkdir -p $DEB_ROOT$INSTALL_PATH
-mkdir -p $DEB_ROOT/usr/share/applications
+if [ ! -d "deb_tmp" ]; then
+  mkdir -p deb_tmp
+fi
+mkdir -p ${DEB_ROOT}${INSTALL_PATH}
+mkdir -p ${DEB_ROOT}/usr/share/applications
 
-tar cf - --exclude=deb_tmp --exclude=./.git . | (cd $DEB_ROOT$INSTALL_PATH && tar xvf - > /dev/null)
+tar cf - --exclude=deb_tmp --exclude=./.git . | (cd ${DEB_ROOT}${INSTALL_PATH} && tar xvf - > /dev/null)
 
-cp wifi-pumpkin.desktop $DEB_ROOT/usr/share/applications/wifi-pumpkin.desktop
+cp wifi-pumpkin.desktop ${DEB_ROOT}/usr/share/applications/wifi-pumpkin.desktop
 
-mkdir -p $DEB_ROOT/DEBIAN
-SIZE=$(du -sb $DEB_ROOT$INSTALL_PATH | cut -f1 | awk '{print $1/1024}')
+mkdir -p ${DEB_ROOT}/DEBIAN
+SIZE=$(du -sb ${DEB_ROOT}${INSTALL_PATH} | cut -f1 | awk '{print $1/1024}')
 
 ###### Start of the DEBIAN/control file ######
 cat > $DEB_ROOT/DEBIAN/control << EOF
@@ -19,16 +24,16 @@ Package: wifi-pumpkin
 Version: $VERSION
 Priority: optional
 Installed-Size: $SIZE
-Architecture: i386
+Architecture: $ARCHITECTURE
 Maintainer: Marcos Nesster <mh4root@gmail.com>
-#Depends: python-pip, libffi-dev, libssl-dev, libxml2-dev, libxslt1-dev, zlib1g-dev, libarchive-dev, build-essential, libnetfilter-queue-dev, python-qt4, python-scapy, hostapd, rfkill, python-dev, git, libpcap-dev
+Depends: python-pip, libffi-dev, libssl-dev, libxml2-dev, libxslt1-dev, zlib1g-dev, libarchive-dev, build-essential, libnetfilter-queue-dev, python-qt4, python-scapy, hostapd, rfkill, python-dev, git, libpcap-dev
 Description: WiFi-Pumpkin
  A tool for creating a WiFi-Hotspot and executing MitM-Attacks
 EOF
 ###### END of the DEBIAN/control file ######
 
 ###### Start of the DEBIAN/postinst file ######
-cat > $DEB_ROOT/DEBIAN/postinst << EOF
+cat > ${DEB_ROOT}/DEBIAN/postinst << EOF
 #!/bin/bash
 pip install -r $INSTALL_PATH/requirements.txt
 if which update-alternatives >/dev/null; then
@@ -40,7 +45,10 @@ if which update-alternatives >/dev/null; then
 EOF
 ###### END of the DEBIAN/postinst file ######
 
-chmod 0755 $DEB_ROOT/DEBIAN/postinst
+chmod 0755 ${DEB_ROOT}/DEBIAN/postinst
 
 cd deb_tmp
-dpkg-deb --build wifi-pumpkin_$VERSION
+dpkg-deb --build wifi-pumpkin_${VERSION}_${ARCHITECTURE}
+cd ..
+
+done

--- a/wifi-pumpkin.desktop
+++ b/wifi-pumpkin.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=WiFi-Pumpkin
 Comment=A tool for creating a WiFi-Hotspot and executing MitM-Attacks
-Exec=wifi-pumpkin
+Exec=gksudo wifi-pumpkin
 Icon=/usr/share/WiFi-Pumpkin/icons/icon.ico
 Terminal=false
 Type=Application

--- a/wifi-pumpkin.desktop
+++ b/wifi-pumpkin.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=WiFi-Pumpkin
+Comment=A tool for creating a WiFi-Hotspot and executing MitM-Attacks
+Exec=wifi-pumpkin
+Icon=/usr/share/WiFi-Pumpkin/icons/icon.ico
+Terminal=false
+Type=Application
+StartupNotify=false


### PR DESCRIPTION
Dependencies from apt are NOT mentioned in the package, because i386 architecture for dependencies is enforced, which may break things/is unnecessary on amd64, because the program also can use the installed amd64 packages.