### PR TITLE
Showing 'lo' as "Not Found", as it doesn't have a MAC

### DIFF
--- a/modules/systems/Macchanger.py
+++ b/modules/systems/Macchanger.py
@@ -44,7 +44,7 @@ class frm_mac_generator(PumpkinModule):
 
     @pyqtSlot(QModelIndex)
     def combo_clicked(self, device):
-        if device == '':
+        if device == '' or device == 'lo':
             self.i_mac.setText('Not Found')
             return
         self.i_mac.setText(Refactor.get_interface_mac(device))


### PR DESCRIPTION
Maybe it should be hidden completely, to prevent people from setting the MAC on the loopback device