### PR TITLE
utils.py use module from Python3

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -11,7 +11,10 @@ from PyQt4 import QtCore
 from PyQt4 import QtGui
 import logging
 import signal
-import configparser
+try:
+    import configparser
+except:
+    import ConfigParser as configparser
 import core.utility.constants as C
 from shlex import split
 from glob import glob


### PR DESCRIPTION
WiFi-Pumpkin use Python 2.7 but we don't have module `configparser` in Py2.7
in 2.7 we have ConfigParser