### PR TITLE
import logging in StartMSF.py

### DIFF
--- a/plugins/external/sergio_proxy/plugins/StartMSF.py
+++ b/plugins/external/sergio_proxy/plugins/StartMSF.py
@@ -1,6 +1,7 @@
 from plugins.external.sergio_proxy.plugins.plugin import Plugin
 from subprocess import Popen
 from tempfile import NamedTemporaryFile
+import logging
 import os
 from pipes import quote
 #Uncomment to use


### PR DESCRIPTION
__logging__ is used on line 34 but is never imported.  Discovered via #375