### PR TITLE
Update installer.sh

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -77,7 +77,7 @@ func_install(){
 		-O /tmp/mitmproxy_0.18.2-6_all.deb
 	gdebi --non-interactive /tmp/mitmproxy_0.18.2-6_all.deb
     else
-	pip install mitmproxy=0.18.2
+	pip install mitmproxy==0.18.2
     fi
     	
 	echo "[=] $bldblu Install WiFi-Pumpkin $txtrst"


### PR DESCRIPTION
Hello. I noticed an error when i run installer.sh (Invalid requirement: 'mitmproxy=0.18.2'
= is not a valid operator. Did you mean == ? ). So the change in line 80 was - pip install mitmproxy=0.18.2 and i think is missing an "=". I  am running kali linux 2018.4.